### PR TITLE
Fix audio permission

### DIFF
--- a/org.quelea.Quelea.yml
+++ b/org.quelea.Quelea.yml
@@ -13,6 +13,8 @@ finish-args:
   - --share=ipc
   # GPU acceleration if needed
   - --device=dri
+  # Audio
+  - --socket=pulseaudio
   # Needs to talk to the network:
   - --share=network
   # Needs to save files locally


### PR DESCRIPTION
The audio permission is needed in order to hear the audio from videos or other multimedia played through the software.